### PR TITLE
Fix doc tests

### DIFF
--- a/test/ssdp_test.exs
+++ b/test/ssdp_test.exs
@@ -1,6 +1,6 @@
 defmodule SsdpTest do
   use ExUnit.Case
-  doctest Ssdp
+  doctest SSDP
 
   test "the truth" do
     assert 1 + 1 == 2


### PR DESCRIPTION
When running `mix test` I was getting the following error:

```elixir
09:46:58.780 [error] beam/beam_load.c(1412): Error loading module 'Elixir.Ssdp':
  module name in object code is Elixir.SSDP

** (CompileError) test/ssdp_test.exs:3: module Ssdp is not loaded and could not be found
    (ex_unit) expanding macro: ExUnit.DocTest.doctest/1
    test/ssdp_test.exs:3: SsdpTest (module)
    (elixir) lib/code.ex:376: Code.require_file/2
    (elixir) lib/kernel/parallel_require.ex:59: anonymous fn/2 in Kernel.ParallelRequire.spawn_requires/5
```

This PR fixes that issue.